### PR TITLE
Фикс перезаписи даты во время получения данных расписания

### DIFF
--- a/app/src/main/java/org/bxkr/octodiary/DataService.kt
+++ b/app/src/main/java/org/bxkr/octodiary/DataService.kt
@@ -211,11 +211,9 @@ object DataService {
         assert(this::profile.isInitialized)
         val startDate = Calendar.getInstance().also {
             it.set(Calendar.WEEK_OF_YEAR, it.get(Calendar.WEEK_OF_YEAR) - weeksBefore)
-            it.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
         }
         val endDate = Calendar.getInstance().also {
             it.set(Calendar.WEEK_OF_YEAR, it.get(Calendar.WEEK_OF_YEAR) + weeksAfter)
-            it.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY)
         }
         secondaryApi.events(
             "Bearer $token",

--- a/app/src/main/java/org/bxkr/octodiary/DataService.kt
+++ b/app/src/main/java/org/bxkr/octodiary/DataService.kt
@@ -237,12 +237,10 @@ object DataService {
         val startDate = Calendar.getInstance().also {
             it.time = date
             it.set(Calendar.WEEK_OF_YEAR, it.get(Calendar.WEEK_OF_YEAR))
-            it.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
         }
         val endDate = Calendar.getInstance().also {
             it.time = date
             it.set(Calendar.WEEK_OF_YEAR, it.get(Calendar.WEEK_OF_YEAR))
-            it.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY)
         }
         secondaryApi.events(
             "Bearer $token",


### PR DESCRIPTION
Во время отправки запроса на получение расписания в дневнике и на домашней странице, дата начала и конца всегда перезаписывалась на понедельник и прошлое воскресенье, что:
1. Возвращало 0 уроков.
2. Отличалось от даты, запрошенной пользователем.

![image](https://github.com/user-attachments/assets/41ae25ed-160e-475e-8888-b2f40026d7b2)
В данном случае, дата была указана на один день назад (10 марта - 9 марта).

С фиксом, дата начала и конца совпадает с датой, запрошенной пользователем.
![image](https://github.com/user-attachments/assets/2574de4d-dab2-49c4-b4a4-4a791ffc1be8)